### PR TITLE
Add openssh-client to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@
 #     docker build --rm=true -t plugins/drone-rsync .
 
 FROM alpine:3.2
-RUN apk add -U ca-certificates rsync && rm -rf /var/cache/apk/*
+RUN apk add -U ca-certificates openssh-client rsync && rm -rf /var/cache/apk/*
 ADD drone-rsync /bin/
 ENTRYPOINT ["/bin/drone-rsync"]


### PR DESCRIPTION
I was trying out this plugin and got the following error:

```
rsync: Failed to exec ssh: No such file or directory (2)
rsync error: error in IPC code (code 14) at pipe.c(85) [sender=3.1.1]
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in IPC code (code 14) at io.c(226) [sender=3.1.1]
```

Adding `openssh-client` to the Docker image appears to solve the problem.
